### PR TITLE
Fixed linux wkhtmltoimage detection

### DIFF
--- a/Html2ImageConverter/Converter/Html2Image.cs
+++ b/Html2ImageConverter/Converter/Html2Image.cs
@@ -58,7 +58,7 @@ namespace Html2ImageConverter.Converter
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     FileName = "/bin/bash",
-                    Arguments = "which wkhtmltoimage"
+                    Arguments = "-c \"which wkhtmltoimage\""
 
                 });
                 string answer = process.StandardOutput.ReadToEnd();


### PR DESCRIPTION
Fixed linux wkhtmltoimage detection always failing because of passing arguments to bash without using -c.
The problem was that it would fail for me everytime I wouldn't supply -c (bash -c "command")
<img width="633" height="82" alt="image" src="https://github.com/user-attachments/assets/c6aed0dc-6668-4c06-8cb8-1ab7b4bb95fe" />
(/usr/bin/which binary cannot be executed)